### PR TITLE
Implement support for drag reordering on web and mobile

### DIFF
--- a/dataview_behavior.livecodescript
+++ b/dataview_behavior.livecodescript
@@ -2131,10 +2131,10 @@ on dvDragMove pMouseH, pMouseV, pDragMoveTarget
 
     # Make sure that this DataView is the actual target of the message. If the user drags over multiple DataViews
     # during a drag session then this instance will get the message even if it isn't the target.
-    if the mouseControl is not empty and the dvControl of the long id of the mousecontrol is the long id of me then
+    if controlAtLoc(the mouseLoc) is not empty and the dvControl of the long id of controlAtLoc(the mouseLoc) is the long id of me then
       local tTargetControlId
 
-      put the dvRowControl of the mouseControl into tTargetControlId
+      put the dvRowControl of controlAtLoc(the mouseLoc) into tTargetControlId
 
       if tTargetControlId is not empty then
         put the short id of tTargetControlId into tTargetControlId
@@ -5290,6 +5290,7 @@ private command _createDragImageFromControl pControlId
     reset the templateImage
     create image "dvDragImage" in group "dvListMask" of me
     set the visible of it to false
+    set the disabled of it to true
   end if
 
   unlock messages

--- a/track_drag_drop_behavior.livecodescript
+++ b/track_drag_drop_behavior.livecodescript
@@ -27,16 +27,30 @@ end dvFreezeMouseRelatedDragMessagesPriorToCleanup
 
 
 on dragDrop
+  _doDragDrop
+
+  pass dragDrop
+end dragDrop
+
+/* On web/mobile the drag drop will result in a mouseRelease event due to the
+ * mouse up being off the original target */
+ on mouseRelease
+  if the platform is "web" or the environment is "mobile" then
+    _doDragDrop
+    _doDragEnd
+  end if
+
+  pass mouseRelease
+end mouseRelease
+
+private command _doDragDrop
   repeat for each key tControl in sControlsA
     if tControl is in the long id of the target then
       dispatch "dvDragDrop" to tControl
       exit repeat
     end if
   end repeat
-
-  pass dragDrop
-end dragDrop
-
+end _doDragDrop
 
 /**
 Summary: Restore pre-drag state after drag operation is complete.
@@ -45,38 +59,84 @@ Description: After the drag is finished we need to reset any DataViews that
 were part of the drag operation.
 */
 on dragEnd
-  local tControl
-  local tFoundAMatch = "false"
-
-  repeat for each key tControl in sControlsA
-    dispatch "dvDragEnd" to tControl
-  end repeat
+  _doDragEnd
 
   pass dragEnd
 end dragEnd
 
+/* On web/mobile a mouseUp is dropping on the original mouse target so a non-envent */
+ on mouseUp
+  if the platform is "web" or the environment is "mobile" then
+    _doDragEnd
+  end if
+
+  pass mouseUp
+end mouseUp
+
+private command _doDragEnd
+  local tControl
+  repeat for each key tControl in sControlsA
+    set the visible of image "dvDragImage" of tControl to false
+    dispatch "dvDragEnd" to tControl
+  end repeat
+end _doDragEnd
 
 on dragMove pMouseH,pMouseV
-  if not sDispatchMessages then pass dragMove
-
-  local tControl
-
-  repeat for each key tControl in sControlsA
-    dispatch "dvDragMove" to tControl with pMouseH, pMouseV, the long id of the target
-  end repeat
+  _doDragMove pMouseH, pMouseV, the long id of the target
 
   pass dragMove
 end dragMove
 
+on mouseMove pMouseH, pMouseV
+  if the platform is "web" or the environment is "mobile" then
+    local tControl
+    repeat for each key tControl in sControlsA
+      if there is an image "dvDragImage" of tControl then
+        /* Show the image with an offset so users can see the indicator */
+        show image "dvDragImage" of tControl \
+          at item 1 of the loc of tControl, \
+            pMouseV + the height of image "dvDragImage" of tControl div 3
+      end if
+    end repeat
 
-on dragLeave
-  if not sDispatchMessages then pass dragLeave
+    _doDragMove pMouseH, pMouseV, the long id of the mouseControl
+  end if
+
+  pass mouseMove
+end mouseMove
+
+private command _doDragMove pMouseH, pMouseV, pTarget
+  if not sDispatchMessages then
+    exit _doDragMove
+  end if
 
   local tControl
-
   repeat for each key tControl in sControlsA
-    dispatch "dvDragLeave" to tControl
+    dispatch "dvDragMove" to tControl with pMouseH, pMouseV, pTarget
   end repeat
+end _doDragMove
+
+on dragLeave
+  _doDragLeave
 
   pass dragLeave
 end dragLeave
+
+on mouseLeave
+  if the platform is "web" or the environment is "mobile" then
+    _doDragLeave
+  end if
+
+  pass mouseLeave
+end mouseLeave
+
+private command _doDragLeave
+  if not sDispatchMessages then
+    exit _doDragLeave
+  end if
+
+  local tControl
+  repeat for each key tControl in sControlsA
+    dispatch "dvDragLeave" to tControl
+  end repeat
+end _doDragLeave


### PR DESCRIPTION
This patch adds support for using mouse events to do drag reordering rather than drag events that are only available on desktop.

In the example below I haven't implemented the actual data swapping part but the correct rows are being logged from the `AcceptRowDrop` handler

![reorder](https://github.com/trevordevore/levurehelper-dataview/assets/351144/be94b6fc-448a-4412-84e0-d94b5cd32c73)

Closes #19 